### PR TITLE
Normalize movement speed using deltaTime

### DIFF
--- a/game/src/main/java/chon/group/Engine.java
+++ b/game/src/main/java/chon/group/Engine.java
@@ -125,9 +125,22 @@ public class Engine extends Application {
                  *
                  * @param now the timestamp of the current frame in nanoseconds.
                  */
+
+                private long lastTime = 0;
+
                 @Override
                 public void handle(long now) {
-                    double deltaTime = 1.0 / 60.0;
+
+                    if (lastTime == 0) {
+                        lastTime = now;
+                        return;
+                    }
+                    
+                    double deltaTime = (now - lastTime) / 1e9; // Convert nanoseconds to seconds
+                    lastTime = now;
+
+                    deltaTime = Math.min(deltaTime, 0.05); // Cap deltaTime to avoid large jumps
+
 
                     mediator.clearEnvironment();
                     if (environment.getProtagonist().isDead()) {

--- a/game/src/main/java/chon/group/Engine.java
+++ b/game/src/main/java/chon/group/Engine.java
@@ -65,12 +65,12 @@ public class Engine extends Application {
         try {
             /* Initialize the game environment and agents */
             Environment environment = new Environment(0, 0, 1280, 780, "/images/environment/castle.png");
-            Agent chonBota = new Agent(400, 390, 90, 65, 3, 1000, "/images/agents/chonBota.png", false);
-            Weapon cannon = new Cannon(400, 390, 0, 0, 3, 0, "", false);
-            Weapon fireball = new Fireball(400, 390, 0, 0, 3, 0, "", false);
+            Agent chonBota = new Agent(400, 390, 90, 65, 250, 1000, "/images/agents/chonBota.png", false);
+            Weapon cannon = new Cannon(400, 390, 0, 0, 300, 0, "", false);
+            Weapon fireball = new Fireball(400, 390, 0, 0, 300, 0, "", false);
             chonBota.setWeapon(fireball);
 
-            Agent chonBot = new Agent(920, 440, 90, 65, 1, 500, "/images/agents/chonBot.png", true);
+            Agent chonBot = new Agent(920, 440, 90, 65, 120, 500, "/images/agents/chonBot.png", true);
             environment.setProtagonist(chonBota);
             environment.getAgents().add(chonBot);
             environment.setPauseImage("/images/environment/pause.png");
@@ -120,26 +120,23 @@ public class Engine extends Application {
 
             /* Start the game loop */
             new AnimationTimer() {
-
                 /**
                  * The game loop, called on each frame.
                  *
                  * @param now the timestamp of the current frame in nanoseconds.
                  */
                 @Override
-                public void handle(long arg0) {
+                public void handle(long now) {
+                    double deltaTime = 1.0 / 60.0;
+
                     mediator.clearEnvironment();
-                    /* Branching the Game Loop */
-                    /* If the agent died in the last loop */
                     if (environment.getProtagonist().isDead()) {
-                        /* Still prints ongoing messages (e.g., last hit taken) */
                         environment.updateMessages();
-                        environment.updateShots();
+                        environment.updateShots(deltaTime);
                         mediator.drawBackground();
                         mediator.drawAgents();
                         mediator.drawShots();
                         mediator.drawMessages();
-                        /* Rendering the Game Over Screen */
                         mediator.drawGameOver();
                     } else {
                         if (isPaused) {
@@ -147,37 +144,29 @@ public class Engine extends Application {
                             mediator.drawAgents();
                             mediator.drawMessages();
                             mediator.drawShots();
-                            /* Rendering the Pause Screen */
                             mediator.drawPauseScreen();
                         } else {
-                            /* ChonBota Only Moves if the Player Press Something */
-                            /* Update the protagonist's movements if input exists */
                             if (!input.isEmpty()) {
-                                /* ChonBota Shoots Somebody Who Outdrew You */
                                 if (input.contains("SPACE")) {
                                     input.remove("SPACE");
-                                    String direction;
-                                    if (chonBota.isFlipped())
-                                        direction = "LEFT";
-                                    else
-                                        direction = "RIGHT";
-                                    environment.getShots().add(chonBota.getWeapon().fire(chonBota.getPosX(),
-                                            chonBota.getPosY(),
-                                            direction));
+                                    String direction = chonBota.isFlipped() ? "LEFT" : "RIGHT";
+                                    environment.getShots().add(chonBota.getWeapon().fire(
+                                        chonBota.getPosX(), chonBota.getPosY(), direction
+                                    ));
                                 }
-                                /* ChonBota's Movements */
-                                environment.getProtagonist().move(input);
+                                environment.getProtagonist().move(input, deltaTime);
                                 environment.checkBorders();
                             }
-                            /* ChonBot's Automatic Movements */
-                            /* Update the other agents' movements */
                             for (Agent agent : environment.getAgents()) {
-                                agent.chase(environment.getProtagonist().getPosX(),
-                                        environment.getProtagonist().getPosY());
+                                agent.chase(
+                                    environment.getProtagonist().getPosX(),
+                                    environment.getProtagonist().getPosY(),
+                                    deltaTime
+                                );
                             }
-                            /* Render the game environment and agents */
+                                
                             environment.detectCollision();
-                            environment.updateShots();
+                            environment.updateShots(deltaTime);
                             environment.updateMessages();
                             mediator.drawBackground();
                             mediator.drawAgents();
@@ -188,7 +177,6 @@ public class Engine extends Application {
                 }
             }.start();
             theStage.show();
-
         } catch (
 
         Exception e) {

--- a/game/src/main/java/chon/group/game/core/Entity.java
+++ b/game/src/main/java/chon/group/game/core/Entity.java
@@ -266,7 +266,7 @@ public abstract class Entity {
      */
     public void move(List<String> movements, double deltaTime){
         double adjustedSpeed = speed * deltaTime;    
-
+    
         if (movements.contains("RIGHT")) {
             if (flipped)
                 this.flipImage();

--- a/game/src/main/java/chon/group/game/core/Entity.java
+++ b/game/src/main/java/chon/group/game/core/Entity.java
@@ -12,10 +12,10 @@ import javafx.scene.paint.Color;
 public abstract class Entity {
 
     /** X position (horizontal) of the entity. */
-    private int posX;
+    private double posX;
 
     /** Y (vertical) position of the entity. */
-    private int posY;
+    private double posY;
 
     /** Height of the entity. */
     private int height;
@@ -49,7 +49,7 @@ public abstract class Entity {
      * @param health    the entity's health
      * @param pathImage the path to the entity's image
      */
-    public Entity(int posX, int posY, int height, int width, int speed, int health, String pathImage) {
+    public Entity(double posX, double posY, int height, int width, int speed, int health, String pathImage) {
         this.posX = posX;
         this.posY = posY;
         this.height = height;
@@ -72,7 +72,7 @@ public abstract class Entity {
      * @param pathImage the path to the entity's image
      * @param flipped   the entity's direction (RIGHT=0 or LEFT=1)
      */
-    public Entity(int posX, int posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
+    public Entity(double posX, double posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
         this.posX = posX;
         this.posY = posY;
         this.height = height;
@@ -89,7 +89,7 @@ public abstract class Entity {
      *
      * @return the X (horizontal) position of the entity
      */
-    public int getPosX() {
+    public double getPosX() {
         return posX;
     }
 
@@ -98,7 +98,7 @@ public abstract class Entity {
      *
      * @param posX the new X (horizontal) position
      */
-    public void setPosX(int posX) {
+    public void setPosX(double posX) {
         this.posX = posX;
     }
 
@@ -107,7 +107,7 @@ public abstract class Entity {
      *
      * @return the Y (vertical) position of the entity
      */
-    public int getPosY() {
+    public double getPosY() {
         return posY;
     }
 
@@ -116,7 +116,7 @@ public abstract class Entity {
      *
      * @param posY the new Y (vertical) position
      */
-    public void setPosY(int posY) {
+    public void setPosY(double posY) {
         this.posY = posY;
     }
 
@@ -264,19 +264,24 @@ public abstract class Entity {
      * @param movements a list of movement directions ("RIGHT", "LEFT", "UP",
      *                  "DOWN")
      */
-    public void move(List<String> movements) {
+    public void move(List<String> movements, double deltaTime){
+        double adjustedSpeed = speed * deltaTime;    
+
         if (movements.contains("RIGHT")) {
             if (flipped)
                 this.flipImage();
-            setPosX(posX += speed);
-        } else if (movements.contains("LEFT")) {
+            setPosX(posX += adjustedSpeed);
+        } 
+        else if (movements.contains("LEFT")) {
             if (!flipped)
                 this.flipImage();
-            setPosX(posX -= speed);
-        } else if (movements.contains("UP")) {
-            setPosY(posY -= speed);
-        } else if (movements.contains("DOWN")) {
-            setPosY(posY += speed);
+            setPosX(posX -= adjustedSpeed);
+        } 
+        else if (movements.contains("UP")) {
+            setPosY(posY -= adjustedSpeed);
+        } 
+        else if (movements.contains("DOWN")) {
+            setPosY(posY += adjustedSpeed);
         }
     }
 
@@ -286,18 +291,22 @@ public abstract class Entity {
      * @param targetX the target's X (horizontal) position
      * @param targetY the target's Y (vertical) position
      */
-    public void chase(int targetX, int targetY) {
+    public void chase(double targetX, double targetY, double deltaTime) {
         if (targetX > this.posX) {
-            this.move(new ArrayList<String>(List.of("RIGHT")));
-        } else if (targetX < this.posX) {
-            this.move(new ArrayList<String>(List.of("LEFT")));
+            this.move(new ArrayList<>(List.of("RIGHT")), deltaTime);
+        } 
+        else if (targetX < this.posX) {
+            this.move(new ArrayList<>(List.of("LEFT")), deltaTime);
         }
+
         if (targetY > this.posY) {
-            this.move(new ArrayList<String>(List.of("DOWN")));
-        } else if (targetY < this.posY) {
-            this.move(new ArrayList<String>(List.of("UP")));
+            this.move(new ArrayList<>(List.of("DOWN")), deltaTime);
+        } 
+        else if (targetY < this.posY) {
+            this.move(new ArrayList<>(List.of("UP")), deltaTime);
         }
-    }
+    }   
+
 
     /**
      * Makes the Entity take damage.

--- a/game/src/main/java/chon/group/game/domain/agent/Agent.java
+++ b/game/src/main/java/chon/group/game/domain/agent/Agent.java
@@ -35,7 +35,7 @@ public class Agent extends Entity {
      * @param health    the agent's health
      * @param pathImage the path to the agent's image
      */
-    public Agent(int posX, int posY, int height, int width, int speed, int health, String pathImage) {
+    public Agent(double posX, double posY, int height, int width, int speed, int health, String pathImage) {
         super(posX, posY, height, width, speed, health, pathImage);
     }
 
@@ -51,7 +51,7 @@ public class Agent extends Entity {
      * @param pathImage the path to the agent's image
      * @param flipped   the agent's direction (RIGHT=0 or LEFT=1)
      */
-    public Agent(int posX, int posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
+    public Agent(double posX, double posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
         super(posX, posY, height, width, speed, health, pathImage, flipped);
     }
 

--- a/game/src/main/java/chon/group/game/domain/agent/Cannon.java
+++ b/game/src/main/java/chon/group/game/domain/agent/Cannon.java
@@ -6,12 +6,12 @@ import chon.group.game.messaging.Message;
 
 public class Cannon extends Weapon {
 
-    public Cannon(int posX, int posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
+    public Cannon(double posX, double posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
         super(posX, posY, height, width, speed, health, pathImage, flipped);
     }
 
     @Override
-    protected Shot createShot(int posX, int posY, String direction) {
+    protected Shot createShot(double posX, double posY, String direction) {
         if (direction.equals("RIGHT"))
             posX += 64 + 1;
         else
@@ -20,7 +20,7 @@ public class Cannon extends Weapon {
                 posY,
                 42,
                 64,
-                3,
+                300,
                 0,
                 "/images/weapons/missile/missile001.png",
                 false,

--- a/game/src/main/java/chon/group/game/domain/agent/Fireball.java
+++ b/game/src/main/java/chon/group/game/domain/agent/Fireball.java
@@ -6,13 +6,13 @@ import chon.group.game.messaging.Message;
 
 public class Fireball extends Weapon {
 
-    public Fireball(int posX, int posY, int height, int width, int speed, int health, String pathImage,
+    public Fireball(double posX, double posY, int height, int width, int speed, int health, String pathImage,
             boolean flipped) {
         super(posX, posY, height, width, speed, health, pathImage, flipped);
     }
 
     @Override
-    protected Shot createShot(int posX, int posY, String direction) {
+    protected Shot createShot(double posX, double posY, String direction) {
         if (direction.equals("RIGHT"))
             posX += 75 + 1;
         else
@@ -21,7 +21,7 @@ public class Fireball extends Weapon {
                 posY,
                 47,
                 75,
-                3,
+                300,
                 0,
                 "/images/weapons/fireball/fireball001.png",
                 false,

--- a/game/src/main/java/chon/group/game/domain/agent/Shot.java
+++ b/game/src/main/java/chon/group/game/domain/agent/Shot.java
@@ -11,7 +11,7 @@ public class Shot extends Entity {
     private String direction;
     private int damage;
 
-    public Shot(int posX, int posY, int height, int width, int speed, int health, String pathImage, boolean flipped,
+    public Shot(double posX, double posY, int height, int width, int speed, int health, String pathImage, boolean flipped,
             int damage, String direction) {
         super(posX, posY, height, width, speed, health, pathImage, flipped);
         this.damage = damage;

--- a/game/src/main/java/chon/group/game/domain/agent/Weapon.java
+++ b/game/src/main/java/chon/group/game/domain/agent/Weapon.java
@@ -4,13 +4,13 @@ import chon.group.game.core.Entity;
 
 public abstract class Weapon extends Entity {
 
-    public Weapon(int posX, int posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
+    public Weapon(double posX, double posY, int height, int width, int speed, int health, String pathImage, boolean flipped) {
         super(posX, posY, height, width, speed, health, pathImage, flipped);
     }
 
-    protected abstract Shot createShot(int posX, int posY, String direction);
+    protected abstract Shot createShot(double posX, double posY, String direction);
 
-    public Shot fire(int posX, int posY, String direction) {
+    public Shot fire(double posX, double posY, String direction) {
         return this.createShot(posX, posY, direction);
     }
 

--- a/game/src/main/java/chon/group/game/domain/environment/Environment.java
+++ b/game/src/main/java/chon/group/game/domain/environment/Environment.java
@@ -366,7 +366,7 @@ public class Environment {
         }
     }
 
-    public void updateShots() {
+    public void updateShots(double deltaTime) {
         Iterator<Shot> itShot = this.shots.iterator();
         while (itShot.hasNext()) {
             Shot shot = itShot.next();
@@ -388,7 +388,7 @@ public class Environment {
                         }
                     }
                 }
-                shot.move(new ArrayList<>(List.of(shot.getDirection())));
+                shot.move(new ArrayList<>(List.of(shot.getDirection())), deltaTime);
             }
         }
     }

--- a/game/src/main/java/chon/group/game/drawer/JavaFxDrawer.java
+++ b/game/src/main/java/chon/group/game/drawer/JavaFxDrawer.java
@@ -49,7 +49,7 @@ public class JavaFxDrawer {
      * @param width  The width of the image.
      * @param height The height of the image.
      */
-    public void drawImage(Image image, int posX, int posY, int width, int height) {
+    public void drawImage(Image image, double posX, double posY, int width, int height) {
         this.gc.drawImage(image, posX, posY, width, height);
     }
 
@@ -63,7 +63,7 @@ public class JavaFxDrawer {
      * @param posY       The y-coordinate position.
      * @param color      The color of the life bar.
      */
-    public void drawLifeBar(int health, int fullHealth, int width, int posX, int posY, Color color) {
+    public void drawLifeBar(int health, int fullHealth, int width, double posX, double posY, Color color) {
         int borderThickness = 2;
         int barHeight = 5;
         int lifeSpan = Math.round((float) ((health * 100 / fullHealth) * width) / 100);
@@ -85,13 +85,16 @@ public class JavaFxDrawer {
      * @param posX The x-coordinate of the protagonist.
      * @param posY The y-coordinate of the protagonist.
      */
-    public void drawStatusPanel(int posX, int posY) {
+    public void drawStatusPanel(double posX, double posY) {
         Font theFont = Font.font("Verdana", FontWeight.BOLD, 14);
         this.gc.setFont(theFont);
         this.gc.setFill(Color.BLACK);
-        this.gc.fillText("X: " + posX, posX + 10, posY - 40);
-        this.gc.fillText("Y: " + posY, posX + 10, posY - 25);
+
+        // Convert the coordinates to integers for display
+        this.gc.fillText("X: " + (int) posX, posX + 10, posY - 40);
+        this.gc.fillText("Y: " + (int) posY, posX + 10, posY - 25);
     }
+
 
     /**
      * Renders the pause screen, centering the pause image within the environment.


### PR DESCRIPTION
From the issue #79 

The game loop now uses deltaTime to ensure that movement speed remains consistent across different machines, regardless of their performance or frame rate. This prevents issues where the game runs faster or slower depending on the hardware, resulting in a smoother and more uniform gameplay experience